### PR TITLE
URIList format

### DIFF
--- a/player.lua
+++ b/player.lua
@@ -7,6 +7,7 @@
     https://github.com/Ale32bit/Quartz/blob/main/LICENSE
 ]]
 
+local emulateSmallTerm = true
 settings.define("quartz.right", {
     description = "Right speaker",
     default = "right",
@@ -64,8 +65,14 @@ local quartz = {
 
 local running = true
 
-local w, h = term.getSize()
 local current = term.current()
+if emulateSmallTerm then
+    term.setBackgroundColor(colors.brown)
+    term.clear()
+    -- turtle / ni term
+    current = window.create(term.current(), 1, 1, 39, 13, true)
+end
+local w, h = current.getSize()
 quartz.logWindow = window.create(current, 1, 1, w, h, true)
 quartz.guiWindow = window.create(current, 1, 1, w, h, false)
 quartz.termWindow = current
@@ -129,7 +136,8 @@ end
 
 if not speakers.left and not speakers.right and not speakers.distributedMode then
     printError("The configured speakers could not be found.")
-    print("Configure the speakers by setting the peripheral names to the settings \"quartz.left\" and/or \"quartz.right\" with the \"set\" command.")
+    print(
+    "Configure the speakers by setting the peripheral names to the settings \"quartz.left\" and/or \"quartz.right\" with the \"set\" command.")
     return
 end
 

--- a/quartz/lib/urilist.lua
+++ b/quartz/lib/urilist.lua
@@ -9,7 +9,7 @@ local function parse(content)
 
     local metaString = table.remove(lines, 1)
     meta.album = metaString:match("^(.+);") or "Mix"
-    meta.author = metaString:match(";(.+)$") or "Multiple authors"
+    meta.artist = metaString:match(";(.+)$") or "Multiple artists"
     repeat
         local uri = table.remove(lines, 1)
         if http.checkURL(uri) then

--- a/quartz/lib/urilist.lua
+++ b/quartz/lib/urilist.lua
@@ -1,0 +1,25 @@
+local function parse(content)
+    local uris = {}
+    local meta = {}
+
+    local lines = {}
+    for s in content:gmatch("[^\r\n]+") do
+        table.insert(lines, s)
+    end
+
+    local metaString = table.remove(lines, 1)
+    meta.album = metaString:match("^(.+);") or "Mix"
+    meta.author = metaString:match(";(.+)$") or "Multiple authors"
+    repeat
+        local uri = table.remove(lines, 1)
+        if http.checkURL(uri) then
+            table.insert(uris, uri)
+        end
+    until #lines <= 0
+
+    return uris, meta
+end
+
+return {
+    parse = parse,
+}


### PR DESCRIPTION
Add support to a playlist format created for Quartz:
The format is as follows:

First line contains the playlist name (or album name) string and the artists string, separated by a semicolon (;).
The following lines are the URLs of the tracks.

Example:

```
Playlist Name;Artist name
https://example.com/track1.dfpwm
https://example.com/track2.dfpwm
https://example.com/track3.dfpwm
https://example.com/track4.dfpwm
https://example.com/track5.dfpwm
```