### PR TITLE
Add Navidrome share support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ Quartz can be configured with the use of the `set` command.
 | `quartz.distributed`   | Play mono audio on all speakers attached to the network. This setting disables `quartz.left` and `quartz.right`. Fine tune `quartz.distance` for best coverage. | boolean | `false`                  |
 | `quartz.raw`           | Skip the audio filters when decoding DFPWM.                                                                                                                     | boolean | `false`                  |
 | `quartz.stream.server` | Server URL of the conversion service. No trailing slash.                                                                                                        | string  | `https://cc.alexdevs.me` |
+| `quartz.stream.navidromeShares` | Enable Navidrome shares support | boolean | `true` |


### PR DESCRIPTION
This PR adds playback of Navidrome shares from within Quartz. 

This feature is enabled by default and can be disabled with `quartz.stream.navidromeShares`, as the way matching works is kinda iffy and *might* cause issues in the future.